### PR TITLE
Fix data type error when creating timedelta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openhistorian
-version = 1.0.5
+version = 1.0.6
 author = J. Ritchie Carroll
 author_email = rcarroll@gridprotectionalliance.org
 description = openHistorian Python API

--- a/src/gsf/__init__.py
+++ b/src/gsf/__init__.py
@@ -80,7 +80,7 @@ class Ticks:
     
     @staticmethod
     def ToDateTime(ticks: np.uint64) -> datetime:
-        return Empty.DATETIME + timedelta(microseconds = ticks // 10)
+        return Empty.DATETIME + timedelta(microseconds = int(ticks // 10))
 
 class Validate:
     @staticmethod


### PR DESCRIPTION
Using the sample data set, the `readTest.py` script produces the following error.

```
C:\Projects\openhistorian-python\tests>py .\readTest.py
Connecting to openHistorian...
Opening "PPA" database instance...
Requesting metadata from openHistorian...
Received 9,659 bytes of metadata in 0.06 seconds. Decompressing...
Decompressed 79,473 bytes of metadata in 0.00 seconds. Parsing...
Parsed 155 metadata records in 0.01 seconds.
    Discovered:
        149 measurement records
        1 device records, and
        5 phasor records
Queried 1 metadata records associated with "PPA" database instance.
Starting read for 1 points from 2025-05-28 16:17:33.706822 to 2025-05-28 16:17:33.739822...

Failed to connect: unsupported type for timedelta microseconds component: numpy.uint64
...
```

As the error message suggests, `numpy.uint64` needs to be converted to `int` before before assigning to the `microseconds` component of `timedelta`. After the fix, everything works properly.

```
C:\Projects\openhistorian-python>py tests\readTest.py
Connecting to openHistorian...
Opening "PPA" database instance...
Requesting metadata from openHistorian...
Received 9,659 bytes of metadata in 0.01 seconds. Decompressing...
Decompressed 79,473 bytes of metadata in 0.00 seconds. Parsing...
Parsed 155 metadata records in 0.01 seconds.
    Discovered:
        149 measurement records
        1 device records, and
        5 phasor records
Queried 1 metadata records associated with "PPA" database instance.
Starting read for 1 points from 2025-05-28 16:21:35.317001 to 2025-05-28 16:21:35.350001...

    Point 2: TESTDEVICE-FQ [FREQ] @ 2025-05-28 16:21:35.333 = 59.966 [QualityFlags.NORMAL]

Read complete for 1 points in 0.00 seconds.

Disconnecting from openHistorian
```